### PR TITLE
Fix #80: Added a check on current server's php.ini's 'max_execution_time' requiring it to exceed the time specified / tested application's comfortable installation time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Enh #71: Improve requirements array validation (@vjik)
 - Enh #78: Improve result appearance (@luizcmarin)
-
+- Enh #80: Added a check on current server's php.ini's max_execution time requiring it to exceed the time specified / tested application's comfortable installation time. (@rossaddison)
+  
 ## 1.0.0 June 15, 2024
 
 - Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Enh #71: Improve requirements array validation (@vjik)
 - Enh #78: Improve result appearance (@luizcmarin)
-- Enh #80: Added a check on current server's php.ini's max_execution time requiring it to exceed the time specified / tested application's comfortable installation time. (@rossaddison)
+- Enh #80: Added a check on current server's php.ini's 'max_execution_time' requiring it to exceed the time specified / tested application's comfortable installation time. (@rossaddison)
   
 ## 1.0.0 June 15, 2024
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "rossaddison/requirements",
+    "name": "yiisoft/requirements",
     "type": "library",
     "description": "Requirements checker",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "yiisoft/requirements",
+    "name": "rossaddison/requirements",
     "type": "library",
     "description": "Requirements checker",
     "keywords": [

--- a/src/RequirementsChecker.php
+++ b/src/RequirementsChecker.php
@@ -294,6 +294,26 @@ final class RequirementsChecker
         return ($minCheckResult && $maxCheckResult);
     }
 
+    
+    /**
+     * Checks if the php.ini setting 'max_execution_time' exceeds a reliable and tested execution time 
+     * @param string|null $max
+     * @return bool
+     */
+    public function checkMaxExecutionTime(?string $max = null): bool
+    {
+        $maxExecutionTime = ini_get('max_exection_time');
+        if ($max !== null) {
+            if ($maxExecutionTime < $max) {
+                $checkResult = false;
+            } else {
+                $checkResult = true;
+            }
+            return $checkResult;
+        }
+        return false;
+    }
+
     /**
      * Renders a view file.
      * This method includes the view file as a PHP script

--- a/src/RequirementsChecker.php
+++ b/src/RequirementsChecker.php
@@ -296,9 +296,9 @@ final class RequirementsChecker
 
     
     /**
-     * Checks if the php.ini setting 'max_execution_time' exceeds a reliable and tested execution time 
-     * @param string|null $max
-     * @return bool
+     * Checks if the `php.ini` setting `max_execution_time` exceeds the execution time specified.
+     * @param string|null $max Maximum execution time.
+     * @return bool True on success.
      */
     public function checkMaxExecutionTime(?string $max = null): bool
     {

--- a/src/RequirementsChecker.php
+++ b/src/RequirementsChecker.php
@@ -303,15 +303,7 @@ final class RequirementsChecker
     public function checkMaxExecutionTime(?string $max = null): bool
     {
         $maxExecutionTime = ini_get('max_exection_time');
-        if ($max !== null) {
-            if ($maxExecutionTime < $max) {
-                $checkResult = false;
-            } else {
-                $checkResult = true;
-            }
-            return $checkResult;
-        }
-        return false;
+        return $max === null || $maxExecutionTime <= $max;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

This would be a useful check prior to installation preventing unnecessary installation timeouts.
